### PR TITLE
typeset display-mode maths

### DIFF
--- a/bookmarklet.js
+++ b/bookmarklet.js
@@ -9,7 +9,7 @@ javascript:(function() {
         script.type = 'text/javascript';
 
         /* see http://www.mathjax.org/docs/1.1/options/tex2jax.html */
-        config = 'MathJax.Hub.Config({tex2jax:{inlineMath:[[\'$\',\'$\']],processEscapes:true}});MathJax.Hub.Startup.onload();';
+        config = 'MathJax.Hub.Config({tex2jax:{inlineMath:[["$","$"]],displayMath:[["\\\\[","\\\\]"]],processEscapes:true}});MathJax.Hub.Startup.onload();';
 
         if (window.opera) script.innerHTML = config; else script.text = config;
 


### PR DESCRIPTION
I've added the setting to typeset display-mode maths. Is there a reason you didn't have it?
